### PR TITLE
Decouple CUDD library

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,7 @@
 ################################################################################
 
 # Build static library by default
+prefix ?= /usr/local
 BUILD_TYPE ?= static
 
 ifeq ($(BUILD_TYPE), static)
@@ -50,7 +51,7 @@ CFLAGS += $(GC)
 
 # Determining the path to the libcudd.so library
 ifeq ($(CUDD_DIR),)
-	CUDD_LIBRARY_PATH = /usr/local/lib
+	CUDD_LIBRARY_PATH = $(prefix)/lib
 else
 	CUDD_LIBRARY_PATH = $(CUDD_DIR)
 endif
@@ -83,14 +84,14 @@ test:
 HEADER_FILES := $(wildcard src/*.h)
 
 # Generate a list of header file paths in /usr/local/include/
-INSTALLED_HEADERS := $(patsubst src/%.h, /usr/local/include/%.h, $(HEADER_FILES))
+INSTALLED_HEADERS := $(patsubst src/%.h, $(prefix)/include/%.h, $(HEADER_FILES))
 
 install:
-	@mkdir -p /usr/local/lib
-	@mkdir -p /usr/local/include
-	@install -m 777 libSTACCATO.so /usr/local/lib
-	@install -m 777 $(HEADER_FILES) /usr/local/include
+	@mkdir -p $(prefix)/lib
+	@mkdir -p $(prefix)/include
+	@install -m 777 libSTACCATO.so $(prefix)/lib
+	@install -m 777 $(HEADER_FILES) $(prefix)/include
 
 uninstall:
-	@rm -f /usr/local/lib/$(notdir libSTACCATO.so)
+	@rm -f $(prefix)/lib/$(notdir libSTACCATO.so)
 	@rm -f $(INSTALLED_HEADERS)

--- a/src/DSD.h
+++ b/src/DSD.h
@@ -38,13 +38,12 @@
   #define DISABLE_SM
 #endif
 
-#include "util.h"
-#include "cudd.h"
-#include "cuddInt.h"
 #include "fixheap.h"
 #include <assert.h>
+#include <stddef.h>
 #include <stdio.h>
 
+#include "cudd.h"
 
 /*!
   Different DSD types possible

--- a/src/DSDDecompose.c
+++ b/src/DSDDecompose.c
@@ -81,17 +81,15 @@ DSDNode* __DSD_Create(DSDManager* manager, DdNode* f)
         return result;
     }
 
-    temp = DD_ONE(manager->Ddmanager_analogue);
-
     manager->num_entered++;
 
     /*special case for variables*/
-    if((Cudd_Regular(f)->type.kids.T == temp) && (Cudd_Regular(f)->type.kids.E == Cudd_Not(temp)))
+    if(Cudd_bddIsVar(manager->Ddmanager_analogue, f))
     {
         return create_var(manager, f);
     }
 
-    id = Cudd_Regular(f)->index;
+    id = Cudd_NodeReadIndex(f);
     /*temp = manager->Ddmanager_analogue;
       id = *(temp->perm);
       cuddI(manager->Ddmanager_analogue, id);*/	
@@ -99,13 +97,13 @@ DSDNode* __DSD_Create(DSDManager* manager, DdNode* f)
 
     if(!Cudd_IsComplement(f))
     {
-        T = Cudd_Regular(f)->type.kids.T;
-        E = Cudd_Regular(f)->type.kids.E;
+        T = Cudd_T(f);
+        E = Cudd_E(f);
     }
     else
     {
-        T = Cudd_Not(Cudd_Regular(f)->type.kids.T);
-        E = Cudd_Not(Cudd_Regular(f)->type.kids.E);
+        T = Cudd_Not(Cudd_T(f));
+        E = Cudd_Not(Cudd_E(f));
     }
 
     DT = __DSD_Create(manager, T);
@@ -156,8 +154,8 @@ DSDNode *create_var(DSDManager* manager, DdNode* f)
     //Cudd_RecursiveDeref(manager->Ddmanager_analogue, result->bdd_analogue);
     //manager->num_DSD_nodes--;
     
-    assert(Cudd_Regular(f)->index <= SATURATION);
-    SET_CAN((DSD_Regular(result)),(Cudd_Regular(f)->index));
+    assert(Cudd_NodeReadIndex(f) <= SATURATION);
+    SET_CAN((DSD_Regular(result)),(Cudd_NodeReadIndex(f)));
 
     /*DSD node already referenced and initialized)*/
     SET_TYPE(result, VAR);

--- a/src/DSDManager.c
+++ b/src/DSDManager.c
@@ -30,8 +30,10 @@
 *******************************************************************************/
 
 
-#include <stdio.h>
 #include "DSDManager.h"
+
+#include <stdio.h>
+#include <stdlib.h>
 
 FixHeapPtr dsd_malloc_ptr;
 FixHeapPtr actual_malloc_ptr;

--- a/src/DSDNewDecompose.c
+++ b/src/DSDNewDecompose.c
@@ -32,6 +32,7 @@
 
 #include "DSDNewDecompose.h"
 
+#include <stdlib.h>
 
 static ActualNode *Enode;
 static ActualNode *Tnode;

--- a/src/DSDOrDecompose.c
+++ b/src/DSDOrDecompose.c
@@ -32,6 +32,7 @@
 
 #include "DSDOrDecompose.h"
 
+#include <stdlib.h>
 
 DSDNode *BDN_OR_VAR_EXP(DSDManager *manager, DdNode *f, DdNode *top_func, DSDNode *base)
 {
@@ -45,7 +46,7 @@ DSDNode *BDN_OR_VAR_EXP(DSDManager *manager, DdNode *f, DdNode *top_func, DSDNod
 
     count = 1;
 
-    assert(Cudd_Regular(f) != DD_ONE(manager->Ddmanager_analogue));
+    assert(Cudd_Regular(f) != Cudd_ReadOne(manager->Ddmanager_analogue));
     assert(f != NULL);
 
     result = create_DSD_node(manager, f);
@@ -115,7 +116,7 @@ DSDNode *BDN_NOR_VAR_EXP(DSDManager *manager, DdNode *f, DdNode *top_func, DSDNo
 
     SET_TYPE(result, OR);
 
-    assert(Cudd_Regular(f) != DD_ONE(manager->Ddmanager_analogue));
+    assert(Cudd_Regular(f) != Cudd_ReadOne(manager->Ddmanager_analogue));
     assert(f != NULL);
 
     top_node = create_var(manager, top_func);
@@ -167,7 +168,7 @@ DSDNode *BDN_NOR_VAR_DEC(DSDManager *manager, DdNode *f, DdNode *top_func, DSDNo
 
     SET_TYPE(result, OR);
 
-    assert(Cudd_Regular(f) != DD_ONE(manager->Ddmanager_analogue));
+    assert(Cudd_Regular(f) != Cudd_ReadOne(manager->Ddmanager_analogue));
     assert(f != NULL);
 
     top_node = create_var(manager, top_func);
@@ -218,7 +219,7 @@ DSDNode *BDN_OR_VAR_DEC(DSDManager *manager, DdNode *f, DdNode *top_func, DSDNod
 
     SET_TYPE(result, OR);
 
-    assert(Cudd_Regular(f) != DD_ONE(manager->Ddmanager_analogue));
+    assert(Cudd_Regular(f) != Cudd_ReadOne(manager->Ddmanager_analogue));
     assert(f != NULL);
 
     top_node = create_var(manager, top_func);
@@ -269,7 +270,7 @@ DSDNode *BDN_OR_DEC_ACTUALS(DSDManager *manager, DdNode *f, DSDNode *node, Actua
 
     SET_TYPE(result, OR);
 
-    assert(Cudd_Regular(f) != DD_ONE(manager->Ddmanager_analogue));
+    assert(Cudd_Regular(f) != Cudd_ReadOne(manager->Ddmanager_analogue));
     assert(f != NULL);
 
     temp = (ActualNode*) FixHeapMalloc(actual_malloc_ptr);
@@ -350,7 +351,7 @@ DSDNode *BDN_NOR_DEC_ACTUALS(DSDManager *manager, DdNode *f, DSDNode *node, Actu
 
     SET_TYPE(result, OR);
 
-    assert(Cudd_Regular(f) != DD_ONE(manager->Ddmanager_analogue));
+    assert(Cudd_Regular(f) != Cudd_ReadOne(manager->Ddmanager_analogue));
     assert(f != NULL);
 
     __DSD_Ref(manager, node);
@@ -442,7 +443,7 @@ DSDNode *BDN_OR_DEC_DEC(DSDManager *manager, DdNode *f, DSDNode *node1, DSDNode 
         var2 = temp_var;		
     }
 
-    assert(Cudd_Regular(f) != DD_ONE(manager->Ddmanager_analogue));
+    assert(Cudd_Regular(f) != Cudd_ReadOne(manager->Ddmanager_analogue));
     assert(f != NULL);
     assert(var1 != var2);
     assert(var1 < 10000);
@@ -514,7 +515,7 @@ DSDNode *BDN_NOR_DEC_DEC(DSDManager *manager, DdNode *f, DSDNode *node1, DSDNode
     }
 
 
-    assert(Cudd_Regular(f) != DD_ONE(manager->Ddmanager_analogue));
+    assert(Cudd_Regular(f) != Cudd_ReadOne(manager->Ddmanager_analogue));
     assert(f != NULL);
     assert(var1 != var2);
     assert(var1 < 10000);

--- a/src/DSDPrimeDecompose.c
+++ b/src/DSDPrimeDecompose.c
@@ -32,6 +32,8 @@
 
 #include "DSDPrimeDecompose.h"
 
+#include <stdlib.h>
+
 DSDNode *BDN_MUX_VAR_DEC_DEC(DSDManager *manager, DdNode *f, DdNode *top_func, DSDNode *E, DSDNode *T)
 {
     DSDNode *top_node, *efake, *tfake;
@@ -81,7 +83,7 @@ DSDNode *BDN_MUX_VAR_DEC_DEC(DSDManager *manager, DdNode *f, DdNode *top_func, D
         var1 = evar;
     }
 
-    assert(Cudd_Regular(f) != DD_ONE(manager->Ddmanager_analogue));
+    assert(Cudd_Regular(f) != Cudd_ReadOne(manager->Ddmanager_analogue));
     assert(f != NULL);
     assert(var1 < 10000);
     assert(var2 < 10000);
@@ -125,7 +127,7 @@ DSDNode *BDN_MUX_VAR_DEC_DEC(DSDManager *manager, DdNode *f, DdNode *top_func, D
 
 
 #ifndef DISABLE_SBDD
-    result->symbolic_kernel = symbolic_mux(manager->Ddmanager_analogue, Cudd_Regular(top_func)->index, efakevar, tfakevar, top_node, efake, tfake);
+    result->symbolic_kernel = symbolic_mux(manager->Ddmanager_analogue, Cudd_NodeReadIndex(top_func), efakevar, tfakevar, top_node, efake, tfake);
     Cudd_Ref(result->symbolic_kernel);
 #endif
     
@@ -1210,7 +1212,7 @@ int symbolic_finder_builder(DSDManager *manager, DSDNode *node1, DSDNode *node2)
 {
     int found;
     ActualNode *iter;
-    DdNode *result, *temp_result, *symbolic_smasher, top_func;
+    DdNode *result, *temp_result, *symbolic_smasher;
 
     found = 0;
 
@@ -1521,7 +1523,7 @@ DdNode *check_symbolic2(DSDManager *manager, DSDNode *node)
 {
     int found;
     ActualNode *iter;
-    DdNode *result, *temp_result, *symbolic_smasher, top_func;
+    DdNode *result, *temp_result, *symbolic_smasher;
 
     found = 0;
 

--- a/src/DSDUtilities.c
+++ b/src/DSDUtilities.c
@@ -32,6 +32,9 @@
 
 #include "DSDUtilities.h"
 
+#include <stdlib.h>
+#include <string.h>
+
 DdNode *symbolic_merger(DdManager *manager, DdNode *base, DdNode *branch, DdNode* top_func)
 {
     DdNode *pos, *neg, *result;
@@ -432,7 +435,7 @@ void support_create(DSDManager *manager, DSDNode* node)
     {
         node_reg->support = (int*) malloc(sizeof(int) * support_size);
         memset(node_reg->support, 0, sizeof(int) * support_size);
-        (*(node_reg->support + (support_size - 1))) = (*(node_reg->support + ((support_size - 1)))) | (1<<(Cudd_ReadPerm(manager->Ddmanager_analogue, (Cudd_Regular(node_reg->bdd_analogue))->index)%(sizeof(int)*8)));
+        (*(node_reg->support + (support_size - 1))) = (*(node_reg->support + ((support_size - 1)))) | (1<<(Cudd_ReadPerm(manager->Ddmanager_analogue, (Cudd_NodeReadIndex(node_reg->bdd_analogue)))%(sizeof(int)*8)));
         return;
     }
 
@@ -503,7 +506,7 @@ DdNode *symbolic_or(DdManager *manager, DSDNode *node)
     }
 
 
-    cuddDeref(f);
+    Cudd_Deref(f);
     return f;
 
 }
@@ -537,7 +540,7 @@ DdNode *symbolic_xor(DdManager *manager, DSDNode *node)
     }
 
 
-    cuddDeref(f);
+    Cudd_Deref(f);
     return f;
 }
 

--- a/src/DSDXorDecompose.c
+++ b/src/DSDXorDecompose.c
@@ -32,6 +32,7 @@
 
 #include "DSDXorDecompose.h"
 
+#include <stdlib.h>
 
 DSDNode *BDN_NXOR_VAR_EXP(DSDManager *manager, DdNode *f, DdNode *top_func, DSDNode *base)
 {
@@ -49,7 +50,7 @@ DSDNode *BDN_NXOR_VAR_EXP(DSDManager *manager, DdNode *f, DdNode *top_func, DSDN
 
     negative = 1;
 
-    assert(Cudd_Regular(f) != DD_ONE(manager->Ddmanager_analogue));
+    assert(Cudd_Regular(f) != Cudd_ReadOne(manager->Ddmanager_analogue));
     assert(f != NULL);
 
     result = create_DSD_node(manager, f);
@@ -130,7 +131,7 @@ DSDNode *BDN_XOR_VAR_EXP(DSDManager *manager, DdNode *f, DdNode *top_func, DSDNo
 
     int negative;
 
-    assert(Cudd_Regular(f) != DD_ONE(manager->Ddmanager_analogue));
+    assert(Cudd_Regular(f) != Cudd_ReadOne(manager->Ddmanager_analogue));
     assert(f != NULL);
 
     count = 1;
@@ -219,7 +220,7 @@ DSDNode *BDN_NXOR_VAR_DEC(DSDManager *manager, DdNode *f, DdNode *top_func, DSDN
 
     SET_TYPE(result, XOR);
 
-    assert(Cudd_Regular(f) != DD_ONE(manager->Ddmanager_analogue));
+    assert(Cudd_Regular(f) != Cudd_ReadOne(manager->Ddmanager_analogue));
     assert(f != NULL);
 
     top_node = create_var(manager, top_func);
@@ -476,7 +477,7 @@ DSDNode *BDN_NXOR_DEC_ACTUALS(DSDManager *manager, DdNode *f, DSDNode *node, Act
 
     SET_TYPE(result, XOR);
 
-    assert(Cudd_Regular(f) != DD_ONE(manager->Ddmanager_analogue));
+    assert(Cudd_Regular(f) != Cudd_ReadOne(manager->Ddmanager_analogue));
     assert(f != NULL);	
 
 
@@ -589,7 +590,7 @@ DSDNode *BDN_XOR_DEC_DEC(DSDManager *manager, DdNode *f, DSDNode *node1, DSDNode
         var2 = temp_var;		
     }
 
-    assert(Cudd_Regular(f) != DD_ONE(manager->Ddmanager_analogue));
+    assert(Cudd_Regular(f) != Cudd_ReadOne(manager->Ddmanager_analogue));
     assert(f != NULL);
     assert(var1 != var2);
     assert(var1 < 10000);
@@ -688,7 +689,7 @@ DSDNode *BDN_NXOR_DEC_DEC(DSDManager *manager, DdNode *f, DSDNode *node1, DSDNod
         var2 = temp_var;		
     }
 
-    assert(Cudd_Regular(f) != DD_ONE(manager->Ddmanager_analogue));
+    assert(Cudd_Regular(f) != Cudd_ReadOne(manager->Ddmanager_analogue));
     assert(f != NULL);
     assert(var1 != var2);
     assert(var1 < 10000);


### PR DESCRIPTION
STACCATO somewhat relied on the CUDD internals which were actually presented in the API, e.g. the `cuddInt.h` header file. The changes are meant to:
- replace the CUDD internals usage with the appropriate API calls;
- support building STACCATO using an CUDD installation in contrast to the CUDD source repository;
- support custom CUDD and STACCATO install locations (using the GNU Make `prefix` convention[1]).

1. https://www.gnu.org/software/make/manual/make.html#index-prefix